### PR TITLE
bug 1127532 - add SPEC (et al.) for building RPM

### DIFF
--- a/RPM/README.md
+++ b/RPM/README.md
@@ -1,0 +1,25 @@
+# RPM spec for Mozilla Snappy Symbolification Server
+
+This will build an RPM suitable for installation on RHEL7'ish.
+
+# Build
+
+* Ensure that `rpmdevtools` and `mock` are available and initialised:
+    ```
+    $ sudo yum install rpmdevtools mock
+    $ rpmdev-setuptree
+    ```
+
+* Run `autobuild.sh`:
+    ```
+    cd ${repo}/
+    chmod u+x autobuild.sh
+    ./autobuild.sh
+    ```
+
+This will pull `master` and build a package whose version corresponds to the
+datestamp (in epoch) of the most recent commit.
+
+# More info
+
+See the [source repo](https://github.com/mozilla/Snappy-Symbolication-Server/).

--- a/RPM/SOURCES/mozilla-snappy.service
+++ b/RPM/SOURCES/mozilla-snappy.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Snappy Symbolication Server
+ 
+[Service]
+Type=simple
+User=nobody
+Group=nobody
+EnvironmentFile=-/etc/sysconfig/mozilla-snappy
+ExecStart=/usr/bin/symbolicationWebService.py $CMD_OPTS
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/RPM/SOURCES/mozilla-snappy.sysconfig
+++ b/RPM/SOURCES/mozilla-snappy.sysconfig
@@ -1,0 +1,1 @@
+CMD_OPTS="/etc/mozilla-snappy.ini"

--- a/RPM/SPECS/mozilla-snappy.spec
+++ b/RPM/SPECS/mozilla-snappy.spec
@@ -1,0 +1,62 @@
+Name:           mozilla-snappy
+Version:        %{getenv:EPOCH}
+Release:        1%{?dist}
+Summary:        The Snappy Symbolication Server is a Web server for symbolicating Firefox stacks.
+Group:          System Environment/Daemons
+License:        MPLv2.0
+URL:            %{getenv:UPSTREAM}
+Source1:        %{name}.sysconfig
+Source2:        %{name}.service
+Source3:        %{name}.ini
+BuildRoot:      %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
+BuildRequires:  systemd-units
+Requires:       systemd, python
+
+%description
+The Snappy Symbolication Server is a Web server for symbolicating Firefox stacks. It matches PC addresses to modules in memory and looks up the corresponding function names in server-side symbol files (.SYM files).
+
+If you're interested in setting up local symbols for use with the Gecko profiler for Firefox, the following page will be useful to you:
+
+https://developer.mozilla.org/en/Performance/Profiling_with_the_Built-in_Profiler_and_Local_Symbols_on_Windows
+
+%prep
+git clone %{getenv:UPSTREAM} %{_builddir}/snappy-repo
+
+%install
+mkdir -p %{buildroot}/%{_bindir}
+cp %{_builddir}/snappy-repo/*.py %{buildroot}/%{_bindir}
+mkdir -p %{buildroot}/%{_sysconfdir}/sysconfig
+cp %{SOURCE1} %{buildroot}/%{_sysconfdir}/sysconfig/%{name}
+mkdir -p %{buildroot}/%{_unitdir}
+cp %{SOURCE2} %{buildroot}/%{_unitdir}/
+cp %{SOURCE3} %{buildroot}/%{_sysconfdir}
+
+%pre
+
+%post
+%systemd_post %{name}.service
+
+%preun
+%systemd_preun %{name}.service
+
+%postun
+%systemd_postun_with_restart %{name}.service
+
+%clean
+rm -rf %{_builddir}/snappy-repo
+rm -rf %{buildroot}
+
+%files
+%defattr(644,root,root,755)
+%{_sysconfdir}/%{name}.ini
+%{_sysconfdir}/sysconfig/%{name}
+%{_unitdir}/%{name}.service
+%attr(755, root, root) %{_bindir}/symbolicationWebService.py
+%{_bindir}/symFileManager.py
+%{_bindir}/symLogging.py
+%{_bindir}/symbolicationRequest.py
+%doc
+
+%changelog
+* Wed Feb 25 2015 Dan Phrawzty <phrawzty@mozilla.com>
+- made this spec

--- a/RPM/autobuild.sh
+++ b/RPM/autobuild.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# This script automatically builds copies over the systemd unit files, spec files and builds the rpm.
+
+RPM_BUILD_DIR="$HOME/rpmbuild"
+
+export UPSTREAM="https://github.com/mozilla/Snappy-Symbolication-Server"
+commit_date=`curl -s https://api.github.com/repos/mozilla/Snappy-Symbolication-Server/commits?per_page=1 | grep -m 1 date | cut -d '"' -f 4`
+export EPOCH=`date --date="${commit_date}" +%s`
+
+cp ./SPECS/mozilla-snappy.spec $HOME/rpmbuild/SPECS/
+cp ./SOURCES/mozilla-snappy.* $HOME/rpmbuild/SOURCES/
+
+rpmbuild -ba $HOME/rpmbuild/SPECS/mozilla-snappy.spec


### PR DESCRIPTION
Adds the necessary bits and pieces to build an RPM suitable for RHEL7'ish (read: systemd); this is already a real-world use-case for us. :smile: 

cc @rhelmer 
