### PR TITLE
copy ini to sources for RPM build

### DIFF
--- a/RPM/autobuild.sh
+++ b/RPM/autobuild.sh
@@ -9,5 +9,6 @@ export EPOCH=`date --date="${commit_date}" +%s`
 
 cp ./SPECS/mozilla-snappy.spec $HOME/rpmbuild/SPECS/
 cp ./SOURCES/mozilla-snappy.* $HOME/rpmbuild/SOURCES/
+cp ../sample.ini $HOME/rpmbuild/SOURCES/mozilla-snappy.ini
 
 rpmbuild -ba $HOME/rpmbuild/SPECS/mozilla-snappy.spec


### PR DESCRIPTION
The `.gitignore` ignores all INI files except the sample. Woops. :blush: 

@rhelmer `r?`
