### PR TITLE
Switch I/O processing to Tornado framework

### DIFF
--- a/symLogging.py
+++ b/symLogging.py
@@ -1,8 +1,6 @@
 import sys
-import threading
 import time
 import logging
-import os.path
 import os
 import tempfile
 from logging.handlers import RotatingFileHandler
@@ -19,10 +17,11 @@ def mkdir_p(path):
 def SetLoggingOptions(logOptions):
   global gLog
 
+  gLog = logging.getLogger("tornado.application")
+
   fmt = logging.Formatter('%(asctime)s\t%(levelname)s\t%(message)s')
   streamHandler = logging.StreamHandler()
   streamHandler.setFormatter(fmt)
-  gLog = logging.getLogger("Snappy")
   gLog.addHandler(streamHandler)
 
   filepath = logOptions.get('logPath', tempfile.gettempdir())
@@ -49,8 +48,8 @@ def SetLoggingOptions(logOptions):
   gLog.setLevel(logLevel)
 
 def doLog(dbgLevel, string):
-    threadName = threading.currentThread().getName().ljust(12)
-    gLog.log(dbgLevel, "%s\t%s", threadName, string)
+  pid = os.getpid()
+  gLog.log(dbgLevel, "%d\t%s", pid, string)
 
 def LogDebug(string):
   if gLog.isEnabledFor(logging.DEBUG):

--- a/symbolicationWebService.py
+++ b/symbolicationWebService.py
@@ -11,6 +11,7 @@ from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
 from SocketServer import ThreadingMixIn
 import threading
 import json
+import tempfile
 import ConfigParser
 from collections import OrderedDict as _default_dict
 
@@ -37,7 +38,7 @@ gOptions = {
   # "maxCacheEntries": 10 * 1000 * 1000,
   "maxCacheEntries": 100,
   # File in which to persist the list of most-recently-used symbols.
-  "mruSymbolStateFile": "/tmp/snappy-mru-symbols.json",
+  "mruSymbolStateFile": os.path.join(tempfile.gettempdir(), "snappy-mru-symbols.json"),
   # Maximum number of symbol files to persist in the state file between runs.
   "maxMRUSymbolsPersist": 10,
   # Paths to .SYM files


### PR DESCRIPTION
Move the I/O processing from "one thread per connection" to Tornado coroutines. This allows us to process multiple connections in a single thread.

The symbolication code has been moved to a separate process so new connections get accepted fast. This is makes better use of multiple cores.

r? @vdjeric 
