### PR TITLE
Ignore control-c in the symbolication subprocess.

### DIFF
--- a/symbolicationWebService.py
+++ b/symbolicationWebService.py
@@ -9,6 +9,7 @@ import sys
 import os
 import time
 import json
+import signal
 import tempfile
 import ConfigParser
 from collections import OrderedDict as _default_dict
@@ -72,6 +73,9 @@ class CaseSensitiveConfigParser(ConfigParser.SafeConfigParser):
 
 def initializeSubprocess(options):
   global gSymFileManager
+
+  # Ignore ctrl-c in the subprocess
+  signal.signal(signal.SIGINT, signal.SIG_IGN)
 
   # Setup logging in the child process
   SetLoggingOptions(options["Log"])


### PR DESCRIPTION
When we type control-c on the terminal, a SIGINT is sent to the
subprocess. This raises an exception on it and process exit mess up.
Ignore the SIGINT signal so we can exit gracefully.

r? @vdjeric 
