### PR TITLE
Protect against sym files with invalid content headers.

### DIFF
--- a/symFileManager.py
+++ b/symFileManager.py
@@ -114,11 +114,16 @@ class SymFileManager:
         headers = request.info()
         contentEncoding = headers.get("Content-Encoding", "").lower()
         if contentEncoding in ("gzip", "x-gzip", "deflate"):
+          data = request.read()
           # We have to put it in a string IO because gzip looks for
           # the "tell()" file object method
-          request = StringIO(request.read())
-          with gzip.GzipFile(fileobj=request) as f:
-            request = StringIO(f.read())
+          request = StringIO(data)
+          try:
+            with gzip.GzipFile(fileobj=request) as f:
+              request = StringIO(f.read())
+          except Exception:
+            request = StringIO(data.decode('zlib'))
+
         LogMessage("Parsing SYM file at " + url)
         return self.FetchSymbolsFromFileObj(request)
     except Exception as e:


### PR DESCRIPTION
Normally, compressed sym files should use gzip for decompression, but
some might have an invalid header and should be decoded with zlib
decoder.

r? @vdjeric 
