### PR TITLE
Added retry mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ All configuration values should be specified as strings unless otherwise noted.
       for details. This value must be an integer type.
     - `"port"` The port number to serve the DiskCache on. Must be an integer
       type.
+    - `"retries"` Must be an integer type. Sets the maximum number of retries
+      that will be attempted before giving up.
     - `"symbolURLs"` A list of strings, each specifying a URL from which symbols
       can be requested. Symbol files will be requested from each URL at
       `<url>/<module>/<breakpadId>/<symbol filename>`.

--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ All configuration values should be specified as strings unless otherwise noted.
       type.
     - `"retries"` Must be an integer type. Sets the maximum number of retries
       that will be attempted before giving up.
+    - `"retryDelayMs"` Must be an integer type. Sets the approximate amount of
+      delay between retries.
     - `"symbolURLs"` A list of strings, each specifying a URL from which symbols
       can be requested. Symbol files will be requested from each URL at
       `<url>/<module>/<breakpadId>/<symbol filename>`.

--- a/sample_config.json
+++ b/sample_config.json
@@ -23,6 +23,7 @@
     ],
     "DiskCacheServer": "127.0.0.1:8888",
     "retries": 3,
+    "retryDelayMs": 500,
     "log": {
       "path": "SymServer.log",
       "level": 30,

--- a/sample_config.json
+++ b/sample_config.json
@@ -22,6 +22,7 @@
       "127.0.0.1:11211"
     ],
     "DiskCacheServer": "127.0.0.1:8888",
+    "retries": 3,
     "log": {
       "path": "SymServer.log",
       "level": 30,

--- a/snappy/DiskCache_Config.py
+++ b/snappy/DiskCache_Config.py
@@ -11,6 +11,7 @@ class Config(dict):
         self['localSymbolDirs'] = []
         self['maxSizeMB'] = 200
         self['port'] = 8888
+        self['retries'] = 3
         self['symbolURLs'] = [
             "https://s3-us-west-2.amazonaws.com/org.mozilla.crash-stats.symbols-public/v1/"
         ]

--- a/snappy/DiskCache_Config.py
+++ b/snappy/DiskCache_Config.py
@@ -12,6 +12,7 @@ class Config(dict):
         self['maxSizeMB'] = 200
         self['port'] = 8888
         self['retries'] = 3
+        self['retryDelayMs'] = 500
         self['symbolURLs'] = [
             "https://s3-us-west-2.amazonaws.com/org.mozilla.crash-stats.symbols-public/v1/"
         ]

--- a/travis_config.json
+++ b/travis_config.json
@@ -21,6 +21,7 @@
       "127.0.0.1:11211"
     ],
     "DiskCacheServer": "127.0.0.1:8888",
+    "retries": 15,
     "log": {
       "path": "SymServer.log",
       "level": 30,

--- a/travis_config.json
+++ b/travis_config.json
@@ -22,6 +22,7 @@
     ],
     "DiskCacheServer": "127.0.0.1:8888",
     "retries": 15,
+    "retryDelayMs": 500,
     "log": {
       "path": "SymServer.log",
       "level": 30,


### PR DESCRIPTION
Addresses Issue #43 to add download retries when a download fails. If the server explicitly says that it does not have the file (HTTP 404), no retries will be attempted.
