### PR TITLE
Fix intermittent test failures

### DIFF
--- a/snappy/DiskCache_DiskCache.py
+++ b/snappy/DiskCache_DiskCache.py
@@ -349,7 +349,8 @@ class DiskCacheThread(threading.Thread):
         ])
 
     def makeSymMap(self, data, libId):
-        symMap = {}
+        publicSymbols = {}
+        funcSymbols = {}
         lineNum = 0
         for line in data:
             lineNum += 1
@@ -363,7 +364,7 @@ class DiskCacheThread(threading.Thread):
                     continue
                 address = int(fields[1], 16)
                 symbol = fields[3]
-                symMap[address] = symbol
+                publicSymbols[address] = symbol
             elif line.startswith("FUNC "):
                 line = line.rstrip()
                 fields = line.split(" ", 4)
@@ -374,7 +375,11 @@ class DiskCacheThread(threading.Thread):
                     continue
                 address = int(fields[1], 16)
                 symbol = fields[4]
-                symMap[address] = symbol
+                funcSymbols[address] = symbol
+        # Prioritize PUBLIC symbols over FUNC ones
+        symMap = funcSymbols
+        symMap.update(publicSymbols)
+
         sortedAddresses = sorted(symMap.keys(), reverse=True)
         symmapString = "DiskCache v.1\n"
         for address in sortedAddresses:


### PR DESCRIPTION
This PR should fix the intermittent test failures (not including test timeouts). Tests were occasionally failing with errors indicating that the wrong symbols were being returned. It appears that these problems stem from two issues:
- Symbol Files sometimes contain a FUNC and PUBLIC line referencing the same offset
- Some of the test data seems to be wrong

To address this:
- DiskCache will now prioritize PUBLIC symbols over FUNC ones (see Issue #54)
- I wrote a script to verify all test data. I then manually changed incorrect data in cacheMissRequests.json
