### PR TITLE
Delete empty directories

### DIFF
--- a/snappy/DiskCache_DiskCache.py
+++ b/snappy/DiskCache_DiskCache.py
@@ -548,6 +548,7 @@ class LRUCache:
                 raise ex
             directory = os.path.dirname(directory)
 
+
 class CacheEntry:
     def __init__(self, path):
         self.path = path

--- a/snappy/DiskCache_DiskCache.py
+++ b/snappy/DiskCache_DiskCache.py
@@ -545,7 +545,7 @@ class LRUCache:
             except OSError as ex:
                 if ex.errno == errno.ENOTEMPTY:
                     return
-                raise ex
+                raise
             directory = os.path.dirname(directory)
 
 

--- a/snappy/DiskCache_DiskCache.py
+++ b/snappy/DiskCache_DiskCache.py
@@ -15,6 +15,7 @@ import gzip
 import zlib
 import time
 import collections
+import errno
 
 
 class DiskCache:
@@ -532,7 +533,20 @@ class LRUCache:
         except:
             logger.log(logLevel.ERROR, "Unable to delete file evicted from cache: {}"
                        .format(toEvict.path))
+        self.removeEmptyCacheDirs(os.path.dirname(toEvict.path))
 
+    def removeEmptyCacheDirs(self, directory):
+        while directory != config['cachePath']:
+            # Going for the "easier to ask for forgiveness than permission" model:
+            # Try to remove directory. Check afterwards to see if there was an
+            # error indicating that the directory was not empty
+            try:
+                os.rmdir(directory)
+            except OSError as ex:
+                if ex.errno == errno.ENOTEMPTY:
+                    return
+                raise ex
+            directory = os.path.dirname(directory)
 
 class CacheEntry:
     def __init__(self, path):


### PR DESCRIPTION
Fixes Issue #56 where the DiskCache leaves lots of empty directories in the cache directory. Given enough time running, too many directories could take up a noticeable amount of space.
