### PR TITLE
Support zlib compressed symbol files

### DIFF
--- a/snappy/DiskCache_DiskCache.py
+++ b/snappy/DiskCache_DiskCache.py
@@ -12,7 +12,6 @@ import urllib2
 import contextlib
 from StringIO import StringIO
 import gzip
-import zlib
 import time
 import collections
 import errno

--- a/snappy/DiskCache_DiskCache.py
+++ b/snappy/DiskCache_DiskCache.py
@@ -336,8 +336,9 @@ class DiskCacheThread(threading.Thread):
                 try:
                     with gzip.GzipFile(fileobj=dataStream) as f:
                         return f.read()
-                except zlib.error:
-                    return dataStream.decode('zlib')
+                except EnvironmentError:
+                    dataStream.seek(0)
+                    return dataStream.read().decode('zlib')
         return response.read()
 
     def getSymbolURL(self, symbolURL, libName, breakpadId, fileName):


### PR DESCRIPTION
Regarding issue #68

The error generated when trying to open a zlib stream with the gzip module is an [IOError for the missing header](https://hg.python.org/cpython/file/2.7/Lib/gzip.py#l196) (or an [OSError in Python 3.6](https://hg.python.org/cpython/file/3.6/Lib/gzip.py#l411)).

In the interest of future-proofing I've used an EnvironmentError which includes both IOError and OSError.

The existing code this replaces wouldn't have worked even in the even of a zlib.error, as dataStream does not have a decode method.