### PR TITLE
Use the new index when adding a module to a subrequest

### DIFF
--- a/snappy/SymServer_Symbolicator.py
+++ b/snappy/SymServer_Symbolicator.py
@@ -154,6 +154,7 @@ class SymbolicationThread(threading.Thread):
                     # Need to add this module to the subRequest memory map
                     subRequestMemoryMap.append(module)
                     subRequestModuleIndex[module] = len(subRequestMemoryMap) - 1
+                    subRequestStack[subRequestIndex][0] = subRequestModuleIndex[module]
 
         if unresolvedFrames:
             self.log(logLevel.INFO, "{} frames in not in memcached"

--- a/snappy/SymServer_Symbolicator.py
+++ b/snappy/SymServer_Symbolicator.py
@@ -143,7 +143,7 @@ class SymbolicationThread(threading.Thread):
                     continue
 
                 # Cache miss. Need to get the value from the DiskCache
-                subRequestStack.append(frame)
+                subRequestStack.append(frame[:])
                 subRequestIndex = len(subRequestStack) - 1
                 unresolvedFrames.append((stackIndex, frameIndex, moduleIndex, subRequestIndex))
                 if module not in subRequestModuleIndex:

--- a/snappy/SymServer_Symbolicator.py
+++ b/snappy/SymServer_Symbolicator.py
@@ -146,15 +146,11 @@ class SymbolicationThread(threading.Thread):
                 subRequestStack.append(frame)
                 subRequestIndex = len(subRequestStack) - 1
                 unresolvedFrames.append((stackIndex, frameIndex, moduleIndex, subRequestIndex))
-                if module in subRequestModuleIndex:
-                    # This module is already in the subRequest. Just reference the
-                    # existing module
-                    subRequestStack[subRequestIndex][0] = subRequestModuleIndex[module]
-                else:
+                if module not in subRequestModuleIndex:
                     # Need to add this module to the subRequest memory map
                     subRequestMemoryMap.append(module)
                     subRequestModuleIndex[module] = len(subRequestMemoryMap) - 1
-                    subRequestStack[subRequestIndex][0] = subRequestModuleIndex[module]
+                subRequestStack[subRequestIndex][0] = subRequestModuleIndex[module]
 
         if unresolvedFrames:
             self.log(logLevel.INFO, "{} frames in not in memcached"


### PR DESCRIPTION
To fix issue #70 

This simply replicates setting `subRequestStack[subRequestIndex][0]` (the module index of the most recently-added frame) from a few lines above.

(It might be less redundant to move this out of the `if/else`, removing the `if` branch altogether)